### PR TITLE
feat: check for unsupported OCM configuration type DockerConfig

### DIFF
--- a/internal/ocm-cli/ocm_test.go
+++ b/internal/ocm-cli/ocm_test.go
@@ -46,6 +46,14 @@ func TestExecute(t *testing.T) {
 			ocmConfig:     "./testdata/ocm-config.yaml",
 			expectedError: nil,
 		},
+
+		{
+			desc:          "get componentversion with unsupported ocm config",
+			commands:      []string{"get", "componentversion"},
+			arguments:     []string{"--output", "yaml", ctfIn},
+			ocmConfig:     "./testdata/unsupported-ocm-config.yaml",
+			expectedError: expectError,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -113,6 +121,12 @@ func TestGetComponentVersion(t *testing.T) {
 			componentRef:  ctfIn,
 			ocmConfig:     "./testdata/ocm-config.yaml",
 			expectedError: nil,
+		},
+		{
+			desc:          "get component version with unsupported ocm config",
+			componentRef:  ctfIn,
+			ocmConfig:     "./testdata/unsupported-ocm-config.yaml",
+			expectedError: expectError,
 		},
 		{
 			desc:          "get component version with invalid reference",

--- a/internal/ocm-cli/testdata/ocm-config.yaml
+++ b/internal/ocm-cli/testdata/ocm-config.yaml
@@ -1,7 +1,14 @@
 type: generic.config.ocm.software/v1
 configurations:
   - type: credentials.config.ocm.software
-    repositories:
-      - repository:
-          type: DockerConfig/v1
-          dockerConfigFile: "~/.docker/config.json"
+    consumers:
+      - identity:
+          type: OCIRegistry
+          scheme: https
+          hostname: ghcr.io
+          pathprefix: openmcp-project
+        credentials:
+          - type: Credentials
+            properties:
+              username: some-user
+              password: some-token

--- a/internal/ocm-cli/testdata/unsupported-ocm-config.yaml
+++ b/internal/ocm-cli/testdata/unsupported-ocm-config.yaml
@@ -1,0 +1,7 @@
+type: generic.config.ocm.software/v1
+configurations:
+  - type: credentials.config.ocm.software
+    repositories:
+      - repository:
+          type: DockerConfig/v1
+          dockerConfigFile: "~/.docker/config.json"


### PR DESCRIPTION
**What this PR does / why we need it**:

Using a `DockerConfig` reference in the OCM configuration may result in unspecified behaviour when runnign the bootstrapper in a Docker container.
Therefore the usage of a `DockerConfig` reference should be prohibited.
This change adds a verification step for user provided OCM configuration files. If the configuration contains a `DockerConfig`, an error is returned.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Prevent the usage of a `DockerConfig` reference in the OCM configuration file.
```
