### PR TITLE
fix: never prune the root kustomizations

### DIFF
--- a/internal/deployment-repo/template_transformer.go
+++ b/internal/deployment-repo/template_transformer.go
@@ -177,6 +177,9 @@ func (t *TemplateTransformer) Transform(ctx context.Context, envName, targetDir 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bootstrap",
 			Namespace: "default",
+			Annotations: map[string]string{
+				"kustomize.toolkit.fluxcd.io/prune": "disabled",
+			},
 		},
 		Spec: fluxk.KustomizationSpec{
 			Interval: metav1.Duration{Duration: 10 * time.Minute},

--- a/internal/deployment-repo/testdata/01/expected-repo/resources/fluxcd/flux-kustomization.yaml
+++ b/internal/deployment-repo/testdata/01/expected-repo/resources/fluxcd/flux-kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   name: flux-system
   namespace: flux-system
 spec:

--- a/internal/deployment-repo/testdata/01/expected-repo/resources/root-kustomization.yaml
+++ b/internal/deployment-repo/testdata/01/expected-repo/resources/root-kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   name: bootstrap
   namespace: default
 spec:

--- a/internal/deployment-repo/testdata/01/templates/fluxcd/templates/resources/flux-kustomization.yaml
+++ b/internal/deployment-repo/testdata/01/templates/fluxcd/templates/resources/flux-kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   name: flux-system
   namespace: flux-system
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

The prune on the root kustomization shall be disabled. Otherwise if the kustomization is accidentely deleted in the git repository, the whole openMCP would be deleted and end up in a broken state.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Disable pruning for root kustomization
```
