### PR TITLE
feat: add ocm templating functions

### DIFF
--- a/internal/deployment-repo/templater.go
+++ b/internal/deployment-repo/templater.go
@@ -20,7 +20,7 @@ import (
 // TemplateDir processes the template files in the specified directory and writes
 // the rendered content to the corresponding files in the Git repository's worktree.
 // It uses the provided template directory and Git repository to perform the operations.
-func TemplateDir(templateDirectory string, templateInput map[string]interface{}, repo *git.Repository) error {
+func TemplateDir(ctx context.Context, templateDirectory string, templateInput map[string]interface{}, compGetter *ocmcli.ComponentGetter, repo *git.Repository) error {
 	logger := log.GetLogger()
 
 	workTree, err := repo.Worktree()
@@ -38,7 +38,7 @@ func TemplateDir(templateDirectory string, templateInput map[string]interface{},
 		}
 	}()
 
-	te := template.NewTemplateExecution().WithMissingKeyOption("zero")
+	te := template.NewTemplateExecution().WithOCMComponentGetter(ctx, compGetter).WithMissingKeyOption("zero")
 
 	// Recursively walk through all files in the template directory
 	err = filepath.WalkDir(templateDirectory, func(path string, d os.DirEntry, walkError error) error {

--- a/internal/deployment-repo/testdata/01/component-constructor.yaml
+++ b/internal/deployment-repo/testdata/01/component-constructor.yaml
@@ -25,6 +25,10 @@ components:
         name: gitops-templates
         version: v0.1.1
 
+      - componentName: github.com/openmcp-project/openmcp/releasechannel
+        name: releasechannel
+        version: v2.1.3
+
     resources:
       - name: fluxcd-source-controller
         version: v1.6.2
@@ -153,3 +157,43 @@ components:
         input:
           type: dir
           path: ./templates/openmcp
+
+  - name: github.com/openmcp-project/openmcp/releasechannel
+    version: v2.1.3
+    provider:
+      name: openmcp-project
+
+    componentReferences:
+      - componentName: github.com/openmcp-project/openmcp/releasechannel/crossplane
+        name: crossplane
+        version: v0.0.1
+
+      - componentName: github.com/openmcp-project/openmcp/releasechannel/crossplane
+        name: crossplane
+        version: v0.0.2
+
+  - name: github.com/openmcp-project/openmcp/releasechannel/crossplane
+    version: v0.0.1
+    provider:
+      name: openmcp-project
+
+    resources:
+      - name: image-crossplane
+        type: ociImage
+        version: v0.0.2
+        access:
+          type: ociArtifact
+          imageReference: ghcr.io/openmcp-project/releasechannel/crossplane:v0.0.2
+
+  - name: github.com/openmcp-project/openmcp/releasechannel/crossplane
+    version: v0.0.2
+    provider:
+      name: openmcp-project
+
+    resources:
+      - name: image-crossplane
+        type: ociImage
+        version: v0.0.2
+        access:
+          type: ociArtifact
+          imageReference: ghcr.io/openmcp-project/releasechannel/crossplane:v0.0.2

--- a/internal/deployment-repo/testdata/01/expected-repo/resources/openmcp/extra/test-configmap.yaml
+++ b/internal/deployment-repo/testdata/01/expected-repo/resources/openmcp/extra/test-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: test-configmap
+    namespace: default
+data:
+    key: "value"
+    repository: "{{OCM_REPO_URL}}"
+    crossplaneComponentName: "github.com/openmcp-project/openmcp/releasechannel/crossplane"
+    crossplaneComponentVersion: "v0.0.1"
+    crossplaneImage: "ghcr.io/openmcp-project/releasechannel/crossplane"
+    crossplaneVersions: |
+      - v0.0.1
+      - v0.0.2

--- a/internal/deployment-repo/testdata/01/expected-repo/resources/openmcp/kustomization.yaml
+++ b/internal/deployment-repo/testdata/01/expected-repo/resources/openmcp/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
 - cluster-providers/test.yaml
 - service-providers/test.yaml
 - platform-services/test.yaml
+- extra/test-configmap.yaml

--- a/internal/deployment-repo/testdata/01/extra-manifests/test-configmap.yaml
+++ b/internal/deployment-repo/testdata/01/extra-manifests/test-configmap.yaml
@@ -5,3 +5,16 @@ metadata:
     namespace: default
 data:
     key: "value"
+    repository: "{{ getOCMRepository }}"
+    {{- $releaseChannelCv := getComponentVersionByReference "releasechannel"  }}
+    {{- $crossplaneCv := getComponentVersionByReference $releaseChannelCv "crossplane"  }}
+    {{- $crossplaneImageResource := getResourceFromComponentVersion $crossplaneCv "image-crossplane" }}
+    {{- $imageReference := dig "access" "imageReference" "none" $crossplaneImageResource }}
+    {{- $parsedImage := parseImage $imageReference }}
+    {{- $crossplaneCvMap := componentVersionAsMap $crossplaneCv }}
+    crossplaneComponentName: "{{ dig "component" "name" "none" $crossplaneCvMap }}"
+    crossplaneComponentVersion: "{{ dig "component" "version" "none" $crossplaneCvMap }}"
+    crossplaneImage: "{{ dig "image" "none" $parsedImage }}"
+    crossplaneVersions: |
+    {{- $crossplaneVersions := listComponentVersions $crossplaneCv }}
+{{ toYaml (sortAlpha $crossplaneVersions) | indent 6 }}

--- a/internal/ocm-cli/component_getter.go
+++ b/internal/ocm-cli/component_getter.go
@@ -77,6 +77,14 @@ func (g *ComponentGetter) TemplatesResourceName() string {
 	return g.templatesResourceName
 }
 
+func (g *ComponentGetter) Repository() string {
+	return g.repo
+}
+
+func (g *ComponentGetter) OCMConfig() string {
+	return g.ocmConfig
+}
+
 func (g *ComponentGetter) GetReferencedComponentVersion(ctx context.Context, parentCV *ComponentVersion, refName string) (*ComponentVersion, error) {
 	ref, err := parentCV.GetComponentReference(refName)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds templating functions for retrieving and inspectinc OCM component versions.
The templating is now also applied to the extra manifests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add OCM component version templating funtions
```
