### PR TITLE
fix: disable copy sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Optional parameters:
 * `--ocm-config`: Path to the OCM configuration file.
 
 ```shell
-openmcp-bootstrapper ocmTransfer <source-location> <target-location> --config <path-to-ocm-config>
+openmcp-bootstrapper ocm-transfer <source-location> <target-location> --config <path-to-ocm-config>
 ```
 
 This command internally calls the OCM cli with the following command and arguments:

--- a/cmd/ocm_transfer.go
+++ b/cmd/ocm_transfer.go
@@ -33,7 +33,6 @@ var ocmTransferCmd = &cobra.Command{
 		transferArgs := []string{
 			"--recursive",
 			"--copy-resources",
-			"--copy-sources",
 			args[0], // source
 			args[1], // target
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable `copy-sources` during the `ocm-transfer` command. Otherwise the user would need credentials to pull the Git sources, which is not needed for the bootstrapping anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Disable `copy-sources` during command `ocm-transfer`
```
