### PR TITLE
fix: using tag for both alpine base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Download and extract ocm binary
-FROM alpine@sha256:f5064d3e5f88c467c714509f491853ab2d951932c5cad699c0cb969dcec6f3b4 AS downloader
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS downloader
 ARG TARGETOS
 ARG TARGETARCH
 RUN apk add --no-cache curl tar


### PR DESCRIPTION

**What this PR does / why we need it**:
as renovate opens 2 different PRs to update
1. https://github.com/openmcp-project/bootstrapper/pull/244/changes
2. https://github.com/openmcp-project/bootstrapper/pull/245/changes
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
