### PR TITLE
feat: propagate repository.provider to Flux GitRepository spec.provider

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ type DeploymentRepository struct {
 	RepoURL    string `json:"url"`
 	PullBranch string `json:"pullBranch"`
 	PushBranch string `json:"pushBranch"`
+	// Provider sets the Flux GitRepository spec.provider (e.g. "github" for GitHub App auth).
+	// Empty preserves the default secretRef-based auth.
+	Provider string `json:"provider"`
 }
 
 type TargetCluster struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,10 @@ func (c *BootstrapperConfig) SetDefaults() {
 	if len(c.DeploymentRepository.PullBranch) == 0 {
 		c.DeploymentRepository.PullBranch = c.DeploymentRepository.PushBranch
 	}
+
+	if len(c.DeploymentRepository.Provider) == 0 {
+		c.DeploymentRepository.Provider = "generic"
+	}
 }
 
 func (c *BootstrapperConfig) Validate() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,42 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openmcp-project/bootstrapper/internal/config"
+)
+
+func TestSetDefaults_Provider(t *testing.T) {
+	tests := []struct {
+		name             string
+		provider         string
+		expectedProvider string
+	}{
+		{
+			name:             "unset provider defaults to generic",
+			provider:         "",
+			expectedProvider: "generic",
+		},
+		{
+			name:             "explicit provider preserved",
+			provider:         "github",
+			expectedProvider: "github",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.BootstrapperConfig{
+				DeploymentRepository: config.DeploymentRepository{
+					RepoURL:    "https://example.com/repo",
+					PushBranch: "main",
+					Provider:   tt.provider,
+				},
+			}
+			cfg.SetDefaults()
+			assert.Equal(t, tt.expectedProvider, cfg.DeploymentRepository.Provider)
+		})
+	}
+}

--- a/internal/deployment-repo/deploymentRepoManager.go
+++ b/internal/deployment-repo/deploymentRepoManager.go
@@ -248,6 +248,7 @@ func (m *DeploymentRepoManager) ApplyTemplates(ctx context.Context) error {
 		"repoUrl":    m.Config.DeploymentRepository.RepoURL,
 		"pushBranch": m.Config.DeploymentRepository.PushBranch,
 		"pullBranch": m.Config.DeploymentRepository.PullBranch,
+		"provider":   m.Config.DeploymentRepository.Provider,
 	}
 
 	templateInput["images"] = make(map[string]interface{})

--- a/internal/deployment-repo/deploymentRepoManager_test.go
+++ b/internal/deployment-repo/deploymentRepoManager_test.go
@@ -57,6 +57,7 @@ func TestDeploymentRepoManager(t *testing.T) {
 			RepoURL:    originDir,
 			PushBranch: incomingBranch,
 			PullBranch: outgoingBranch,
+			Provider:   "github",
 		},
 		OpenMCPOperator: config.OpenMCPOperator{
 			Config: json.RawMessage(`{"someKey": "someValue"}`),

--- a/internal/deployment-repo/testdata/01/expected-repo/resources/fluxcd/gitrepo.yaml
+++ b/internal/deployment-repo/testdata/01/expected-repo/resources/fluxcd/gitrepo.yaml
@@ -11,3 +11,4 @@ spec:
     branch: "<branch-name>"
   secretRef:
     name: git
+  provider: github

--- a/internal/deployment-repo/testdata/01/templates/fluxcd/templates/resources/gitrepo.yaml
+++ b/internal/deployment-repo/testdata/01/templates/fluxcd/templates/resources/gitrepo.yaml
@@ -11,3 +11,6 @@ spec:
     branch: "<branch-name>"
   secretRef:
     name: git
+  {{- if .Values.git.provider }}
+  provider: {{ .Values.git.provider }}
+  {{- end }}

--- a/internal/flux_deployer/template_input.go
+++ b/internal/flux_deployer/template_input.go
@@ -20,6 +20,7 @@ func NewTemplateInputFromConfig(c *config.BootstrapperConfig) TemplateInput {
 			"repoUrl":    c.DeploymentRepository.RepoURL,
 			"pushBranch": c.DeploymentRepository.PushBranch,
 			"pullBranch": c.DeploymentRepository.PullBranch,
+			"provider":   c.DeploymentRepository.Provider,
 		},
 
 		"imagePullSecrets": wrapImagePullSecrets(c.ImagePullSecrets),

--- a/internal/flux_deployer/template_input_test.go
+++ b/internal/flux_deployer/template_input_test.go
@@ -12,28 +12,49 @@ import (
 )
 
 func TestNewTemplateInputFromConfig(t *testing.T) {
-	config := &config.BootstrapperConfig{
-		Environment: "test-env",
-		DeploymentRepository: config.DeploymentRepository{
-			RepoURL:    "test-repo-url",
-			PullBranch: "test-branch-pull",
-			PushBranch: "test-branch-push",
-			Provider:   "github",
+	tests := []struct {
+		name             string
+		provider         string
+		expectedProvider string
+	}{
+		{
+			name:             "provider set to github",
+			provider:         "github",
+			expectedProvider: "github",
 		},
-		ImagePullSecrets: []string{"test-secret"},
+		{
+			name:             "provider unset passes through as empty",
+			provider:         "",
+			expectedProvider: "",
+		},
 	}
 
-	ti := flux_deployer.NewTemplateInputFromConfig(config)
-	assert.NotNil(t, ti, "Expected non-nil TemplateInput")
-	assert.Equal(t, "./envs/test-env/fluxcd", ti["fluxCDEnvPath"], "fluxCDEnvPath does not match")
-	assert.Equal(t, "../../../resources/fluxcd", ti["fluxCDResourcesPath"], "fluxCDResourcesPath does not match")
-	assert.Equal(t, "../../../resources/openmcp", ti["openMCPResourcesPath"], "openMCPResourcesPath does not match")
-	assert.Len(t, ti["imagePullSecrets"].([]map[string]string), 1, "imagePullSecrets length does not match")
-	assert.Equal(t, "test-secret", ti["imagePullSecrets"].([]map[string]string)[0]["name"], "imagePullSecret name does not match")
-	assert.Equal(t, "test-repo-url", ti["git"].(map[string]interface{})["repoUrl"], "git repoUrl does not match")
-	assert.Equal(t, "test-branch-push", ti["git"].(map[string]interface{})["pushBranch"], "git pushBranch does not match")
-	assert.Equal(t, "test-branch-pull", ti["git"].(map[string]interface{})["pullBranch"], "git pullBranch does not match")
-	assert.Equal(t, "github", ti["git"].(map[string]interface{})["provider"], "git provider does not match")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.BootstrapperConfig{
+				Environment: "test-env",
+				DeploymentRepository: config.DeploymentRepository{
+					RepoURL:    "test-repo-url",
+					PullBranch: "test-branch-pull",
+					PushBranch: "test-branch-push",
+					Provider:   tt.provider,
+				},
+				ImagePullSecrets: []string{"test-secret"},
+			}
+
+			ti := flux_deployer.NewTemplateInputFromConfig(cfg)
+			assert.NotNil(t, ti, "Expected non-nil TemplateInput")
+			assert.Equal(t, "./envs/test-env/fluxcd", ti["fluxCDEnvPath"], "fluxCDEnvPath does not match")
+			assert.Equal(t, "../../../resources/fluxcd", ti["fluxCDResourcesPath"], "fluxCDResourcesPath does not match")
+			assert.Equal(t, "../../../resources/openmcp", ti["openMCPResourcesPath"], "openMCPResourcesPath does not match")
+			assert.Len(t, ti["imagePullSecrets"].([]map[string]string), 1, "imagePullSecrets length does not match")
+			assert.Equal(t, "test-secret", ti["imagePullSecrets"].([]map[string]string)[0]["name"], "imagePullSecret name does not match")
+			assert.Equal(t, "test-repo-url", ti["git"].(map[string]interface{})["repoUrl"], "git repoUrl does not match")
+			assert.Equal(t, "test-branch-push", ti["git"].(map[string]interface{})["pushBranch"], "git pushBranch does not match")
+			assert.Equal(t, "test-branch-pull", ti["git"].(map[string]interface{})["pullBranch"], "git pullBranch does not match")
+			assert.Equal(t, tt.expectedProvider, ti["git"].(map[string]interface{})["provider"], "git provider does not match")
+		})
+	}
 }
 
 func TestTemplateInput_AddImageResource(t *testing.T) {

--- a/internal/flux_deployer/template_input_test.go
+++ b/internal/flux_deployer/template_input_test.go
@@ -18,6 +18,7 @@ func TestNewTemplateInputFromConfig(t *testing.T) {
 			RepoURL:    "test-repo-url",
 			PullBranch: "test-branch-pull",
 			PushBranch: "test-branch-push",
+			Provider:   "github",
 		},
 		ImagePullSecrets: []string{"test-secret"},
 	}
@@ -32,6 +33,7 @@ func TestNewTemplateInputFromConfig(t *testing.T) {
 	assert.Equal(t, "test-repo-url", ti["git"].(map[string]interface{})["repoUrl"], "git repoUrl does not match")
 	assert.Equal(t, "test-branch-push", ti["git"].(map[string]interface{})["pushBranch"], "git pushBranch does not match")
 	assert.Equal(t, "test-branch-pull", ti["git"].(map[string]interface{})["pullBranch"], "git pullBranch does not match")
+	assert.Equal(t, "github", ti["git"].(map[string]interface{})["provider"], "git provider does not match")
 }
 
 func TestTemplateInput_AddImageResource(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Propagates an environment config `repository.provider` (e.g. `github`) into the Flux `GitRepository` `spec.provider`. The gitops-templates `GitRepository` already renders `spec.provider` from `.Values.git.provider`, but the bootstrapper dropped the field: it was absent from the `DeploymentRepository` struct (discarded at config parse) and never added to the git template input in either the `manage-deployment-repo` or `deploy-flux` pipeline. This enables GitHub App auth for the git source.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Empty `provider` preserves existing `secretRef`-based auth (template `{{- if }}` skips the field). The GitHub App credentials secret is provisioned out-of-band. Pairs with openmcp-project/gitops-templates#19 (declares/documents the input).

**Release note**:
```feature user
Environment config `repository.provider` now propagates to the Flux GitRepository `spec.provider`, enabling GitHub App authentication for the git source.
```